### PR TITLE
Add method to return plain text notes

### DIFF
--- a/src/main/kotlin/org/jetbrains/changelog/Changelog.kt
+++ b/src/main/kotlin/org/jetbrains/changelog/Changelog.kt
@@ -101,27 +101,33 @@ class Changelog(extension: ChangelogPluginExtension) {
         }
 
         fun toPlainText() = toText().run {
-            HtmlGenerator(this, parser.buildMarkdownTreeFromString(this), PlainTextFlavourDescriptor(), false).generateHtml(PlainTextTagRenderer())
+            HtmlGenerator(this, parser.buildMarkdownTreeFromString(this), PlainTextFlavourDescriptor(), false)
+                    .generateHtml(PlainTextTagRenderer())
         }
 
         override fun toString() = toText()
     }
 
     private class PlainTextTagRenderer : HtmlGenerator.TagRenderer {
-        override fun openTag(node: ASTNode, tagName: CharSequence, vararg attributes: CharSequence?, autoClose: Boolean) = ""
+        override fun openTag(node: ASTNode, tagName: CharSequence, vararg attributes: CharSequence?, autoClose: Boolean)
+                = ""
         override fun closeTag(tagName: CharSequence) = ""
         override fun printHtml(html: CharSequence) = html
     }
 
     private class PlainTextFlavourDescriptor : GFMFlavourDescriptor() {
-        override fun createHtmlGeneratingProviders(linkMap: LinkMap, baseURI: URI?): Map<IElementType, GeneratingProvider> {
+        override fun createHtmlGeneratingProviders(linkMap: LinkMap, baseURI: URI?)
+                : Map<IElementType, GeneratingProvider> {
+
             return super.createHtmlGeneratingProviders(linkMap, baseURI) + hashMapOf(
                     MarkdownElementTypes.LIST_ITEM to CustomProvider("- "),
                     MarkdownTokenTypes.EOL to CustomProvider("", "\n")
             )
         }
 
-        private class CustomProvider(private val openTagName: String = "", private val closeTagName: String = "") : OpenCloseGeneratingProvider() {
+        private class CustomProvider(private val openTagName: String = "", private val closeTagName: String = "")
+            : OpenCloseGeneratingProvider() {
+
             override fun openTag(visitor: HtmlGenerator.HtmlGeneratingVisitor, text: String, node: ASTNode) {
                 visitor.consumeHtml(openTagName)
             }

--- a/src/main/kotlin/org/jetbrains/changelog/Changelog.kt
+++ b/src/main/kotlin/org/jetbrains/changelog/Changelog.kt
@@ -109,15 +109,19 @@ class Changelog(extension: ChangelogPluginExtension) {
     }
 
     private class PlainTextTagRenderer : HtmlGenerator.TagRenderer {
-        override fun openTag(node: ASTNode, tagName: CharSequence, vararg attributes: CharSequence?, autoClose: Boolean)
-                = ""
+        override fun openTag(
+            node: ASTNode,
+            tagName: CharSequence,
+            vararg attributes: CharSequence?,
+            autoClose: Boolean
+        ) = ""
         override fun closeTag(tagName: CharSequence) = ""
         override fun printHtml(html: CharSequence) = html
     }
 
     private class PlainTextFlavourDescriptor : GFMFlavourDescriptor() {
-        override fun createHtmlGeneratingProviders(linkMap: LinkMap, baseURI: URI?)
-                : Map<IElementType, GeneratingProvider> {
+        override fun createHtmlGeneratingProviders(linkMap: LinkMap, baseURI: URI?):
+                Map<IElementType, GeneratingProvider> {
 
             return super.createHtmlGeneratingProviders(linkMap, baseURI) + hashMapOf(
                     MarkdownElementTypes.LIST_ITEM to CustomProvider("- "),
@@ -125,8 +129,8 @@ class Changelog(extension: ChangelogPluginExtension) {
             )
         }
 
-        private class CustomProvider(private val openTagName: String = "", private val closeTagName: String = "")
-            : OpenCloseGeneratingProvider() {
+        private class CustomProvider(private val openTagName: String = "", private val closeTagName: String = "") :
+                OpenCloseGeneratingProvider() {
 
             override fun openTag(visitor: HtmlGenerator.HtmlGeneratingVisitor, text: String, node: ASTNode) {
                 visitor.consumeHtml(openTagName)

--- a/src/main/kotlin/org/jetbrains/changelog/Changelog.kt
+++ b/src/main/kotlin/org/jetbrains/changelog/Changelog.kt
@@ -2,13 +2,19 @@ package org.jetbrains.changelog
 
 import org.intellij.markdown.IElementType
 import org.intellij.markdown.MarkdownElementTypes
+import org.intellij.markdown.MarkdownTokenTypes
 import org.intellij.markdown.ast.ASTNode
 import org.intellij.markdown.ast.getTextInNode
+import org.intellij.markdown.flavours.gfm.GFMFlavourDescriptor
+import org.intellij.markdown.html.GeneratingProvider
 import org.intellij.markdown.html.HtmlGenerator
+import org.intellij.markdown.html.OpenCloseGeneratingProvider
+import org.intellij.markdown.parser.LinkMap
 import org.intellij.markdown.parser.MarkdownParser
 import org.jetbrains.changelog.exceptions.MissingFileException
 import org.jetbrains.changelog.exceptions.MissingVersionException
 import java.io.File
+import java.net.URI
 
 class Changelog(extension: ChangelogPluginExtension) {
     val content = File(extension.path).run {
@@ -94,7 +100,36 @@ class Changelog(extension: ChangelogPluginExtension) {
             HtmlGenerator(this, parser.buildMarkdownTreeFromString(this), flavour, false).generateHtml()
         }
 
+        fun toPlainText() = toText().run {
+            HtmlGenerator(this, parser.buildMarkdownTreeFromString(this), PlainTextFlavourDescriptor(), false).generateHtml(PlainTextTagRenderer())
+        }
+
         override fun toString() = toText()
+    }
+
+    private class PlainTextTagRenderer : HtmlGenerator.TagRenderer {
+        override fun openTag(node: ASTNode, tagName: CharSequence, vararg attributes: CharSequence?, autoClose: Boolean) = ""
+        override fun closeTag(tagName: CharSequence) = ""
+        override fun printHtml(html: CharSequence) = html
+    }
+
+    private class PlainTextFlavourDescriptor : GFMFlavourDescriptor() {
+        override fun createHtmlGeneratingProviders(linkMap: LinkMap, baseURI: URI?): Map<IElementType, GeneratingProvider> {
+            return super.createHtmlGeneratingProviders(linkMap, baseURI) + hashMapOf(
+                    MarkdownElementTypes.LIST_ITEM to CustomProvider("- "),
+                    MarkdownTokenTypes.EOL to CustomProvider("", "\n")
+            )
+        }
+
+        private class CustomProvider(private val openTagName: String = "", private val closeTagName: String = "") : OpenCloseGeneratingProvider() {
+            override fun openTag(visitor: HtmlGenerator.HtmlGeneratingVisitor, text: String, node: ASTNode) {
+                visitor.consumeHtml(openTagName)
+            }
+
+            override fun closeTag(visitor: HtmlGenerator.HtmlGeneratingVisitor, text: String, node: ASTNode) {
+                visitor.consumeHtml(closeTagName)
+            }
+        }
     }
 
     private fun ASTNode.text() = getTextInNode(content).toString()

--- a/src/test/kotlin/org/jetbrains/changelog/ChangelogPluginExtensionTest.kt
+++ b/src/test/kotlin/org/jetbrains/changelog/ChangelogPluginExtensionTest.kt
@@ -130,8 +130,10 @@ class ChangelogPluginExtensionTest : BaseTest() {
             
             ## [1.0.0]
             ### Added
-            - Foo
-            - Bar
+            - Foo *FOO* foo
+            - Bar **BAR** bar
+            - Test [link](https://www.example.org) test
+            - Code `block` code
             - Bravo
             - Alpha
             
@@ -149,7 +151,7 @@ class ChangelogPluginExtensionTest : BaseTest() {
             withHeader(true).getSections().apply {
                 assertEquals(3, size)
                 assertTrue(containsKey("Added"))
-                assertEquals(4, get("Added")?.size)
+                assertEquals(6, get("Added")?.size)
                 assertTrue(containsKey("Fixed"))
                 assertEquals(2, get("Fixed")?.size)
                 assertTrue(containsKey("Removed"))
@@ -158,8 +160,10 @@ class ChangelogPluginExtensionTest : BaseTest() {
             assertEquals("""
                 ## [1.0.0]
                 ### Added
-                - Foo
-                - Bar
+                - Foo *FOO* foo
+                - Bar **BAR** bar
+                - Test [link](https://www.example.org) test
+                - Code `block` code
                 - Bravo
                 - Alpha
 
@@ -173,7 +177,7 @@ class ChangelogPluginExtensionTest : BaseTest() {
             assertEquals("""
                 <h2>[1.0.0]</h2>
                 <h3>Added</h3>
-                <ul><li>Foo</li><li>Bar</li><li>Bravo</li><li>Alpha</li></ul>
+                <ul><li>Foo <em>FOO</em> foo</li><li>Bar <strong>BAR</strong> bar</li><li>Test <a href="https://www.example.org">link</a> test</li><li>Code <code>block</code> code</li><li>Bravo</li><li>Alpha</li></ul>
                 
                 <h3>Fixed</h3>
                 <ul><li>Hello</li><li>World</li></ul>
@@ -181,6 +185,23 @@ class ChangelogPluginExtensionTest : BaseTest() {
                 <h3>Removed</h3>
                 <ul><li>Hola</li></ul>
             """.trimIndent(), toHTML())
+            assertEquals("""
+                [1.0.0]
+                Added
+                - Foo FOO foo
+                - Bar BAR bar
+                - Test link test
+                - Code block code
+                - Bravo
+                - Alpha
+                
+                Fixed
+                - Hello
+                - World
+                
+                Removed
+                - Hola
+            """.trimIndent(), toPlainText())
         }
     }
 


### PR DESCRIPTION
Adds a `toPlainText()` method to return a stripped text version of the notes that can be used in ReSharper release notes, that expect completely plain text, without any markdown or HTML syntax.

The stripped content is not authoritative, but works for simple changelog format and will remove markdown syntax such as `*emphasis*` and `[link](https://www.example.org)`, but leave in place bullet lists such as `- item 1`.