### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ tasks {
     // ...
 
     patchPluginXml {
-        changeNotes(closure { changelog.getUnreleased().noHeader().toHTML() })
+        changeNotes(closure { changelog.getUnreleased().withHeader(false).toHTML() })
     }
 }
 
@@ -50,7 +50,7 @@ intellij {
     // ...
 
     patchPluginXml {
-        changeNotes({ changelog.getUnreleased().noHeader().toHTML() })
+        changeNotes({ changelog.getUnreleased().withHeader(false).toHTML() })
     }
 }
 
@@ -148,7 +148,7 @@ Kotlin:
 ```kotlin
 tasks {
     patchPluginXml {
-        changeNotes(closure { changelog.get("1.0.0").noHeader().toHTML() })
+        changeNotes(closure { changelog.get("1.0.0").withHeader(false).toHTML() })
     }
 }
 ```
@@ -157,7 +157,7 @@ Groovy:
 ```groovy
 tasks {
     patchPluginXml {
-        changeNotes({ changelog.get("1.0.0").noHeader().toHTML() })
+        changeNotes({ changelog.get("1.0.0").withHeader(false).toHTML() })
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ tasks {
     // ...
 
     patchPluginXml {
-        changeNotes(closure { changelog.getUnreleased().withHeader(false).toHTML() })
+        changeNotes(closure { changelog.getUnreleased().toHTML() })
     }
 }
 
@@ -50,7 +50,7 @@ intellij {
     // ...
 
     patchPluginXml {
-        changeNotes({ changelog.getUnreleased().withHeader(false).toHTML() })
+        changeNotes({ changelog.getUnreleased().toHTML() })
     }
 }
 
@@ -148,7 +148,7 @@ Kotlin:
 ```kotlin
 tasks {
     patchPluginXml {
-        changeNotes(closure { changelog.get("1.0.0").withHeader(false).toHTML() })
+        changeNotes(closure { changelog.get("1.0.0").toHTML() })
     }
 }
 ```
@@ -157,7 +157,7 @@ Groovy:
 ```groovy
 tasks {
     patchPluginXml {
-        changeNotes({ changelog.get("1.0.0").withHeader(false).toHTML() })
+        changeNotes({ changelog.get("1.0.0").toHTML() })
     }
 }
 ```


### PR DESCRIPTION
There is no `noHeader()` method in `Changelog.Item`, so I replaced it with current alternative `withHeader(false)`.
Actually, it seems like there is no need to call `noHeader()` or `withHeader(false)` at all, as `false` will be default value for `withHeader` property (I am not sure about this, though). 