### PR TITLE
Smart processing of 'headerParserRegex' property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,7 @@
 ### Added
 
 ### Changed
-
-### Deprecated
-
-### Removed
-
-### Fixed
-
-### Security
+- Smart processing of `headerParserRegex` property
 
 ## [0.6.1]
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,6 @@
 # Gradle Changelog Plugin
 
 ## [Unreleased]
-### Added
-
 ### Changed
 - Smart processing of `headerParserRegex` property
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ changelog {
     version = "${project.version}"
     path = "${project.projectDir}/CHANGELOG.md"
     header = { "[${project.version}] - ${date()}" }
-    headerParserRegex = new Regex(~/\d+\.\d+/)
+    headerParserRegex = ~/\d+\.\d+/
     itemPrefix = "-"
     keepUnreleasedSection = true
     unreleasedTerm = "[Unreleased]"
@@ -104,17 +104,17 @@ changelog {
 
 Plugin can be configured with the following properties set in the `changelog {}` closure:
 
-| Property                | Description                                                    | Default value                                                        |
-| ----------------------- | -------------------------------------------------------------- | -------------------------------------------------------------------- |
-| `groups`                | List of groups created with a new Unreleased section.          | `["Added", "Changed", "Deprecated", "Removed", "Fixed", "Security"]` |
-| `header`                | Closure that returns current header value.                     | `{ "[${project.version}]" }`                                         |
-| `headerParserRegex`     | `Regex` object used to extract version from the header string. | `null`, fallbacks to [`Changelog#semVerRegex`][semver-regex]         |
-| `itemPrefix`            | Single item's prefix, allows to customise the bullet sign.     | `"-"`                                                                |
-| `keepUnreleasedSection` | Add Unreleased empty section after patching.                   | `true`                                                               |
-| `patchEmpty`            | Patches changelog even if no release note is provided.         | `true`                                                               |
-| `path`                  | Path to the changelog file.                                    | `"${project.projectDir}/CHANGELOG.md"`                               |
-| `unreleasedTerm`        | Unreleased section text.                                       | `"[Unreleased]"`                                                     |
-| `version`               | Current project's version.                                     | `"${project.version}"`                                               |
+| Property                | Description                                                                | Default value                                                        |
+| ----------------------- | -------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| `groups`                | List of groups created with a new Unreleased section.                      | `["Added", "Changed", "Deprecated", "Removed", "Fixed", "Security"]` |
+| `header`                | Closure that returns current header value.                                 | `{ "[${project.version}]" }`                                         |
+| `headerParserRegex`     | `Regex`/`Pattern`/`String` used to extract version from the header string. | `null`, fallbacks to [`Changelog#semVerRegex`][semver-regex]         |
+| `itemPrefix`            | Single item's prefix, allows to customise the bullet sign.                 | `"-"`                                                                |
+| `keepUnreleasedSection` | Add Unreleased empty section after patching.                               | `true`                                                               |
+| `patchEmpty`            | Patches changelog even if no release note is provided.                     | `true`                                                               |
+| `path`                  | Path to the changelog file.                                                | `"${project.projectDir}/CHANGELOG.md"`                               |
+| `unreleasedTerm`        | Unreleased section text.                                                   | `"[Unreleased]"`                                                     |
+| `version`               | Current project's version.                                                 | `"${project.version}"`                                               |
 
 
 ## Tasks

--- a/src/main/kotlin/org/jetbrains/changelog/Changelog.kt
+++ b/src/main/kotlin/org/jetbrains/changelog/Changelog.kt
@@ -33,7 +33,7 @@ class Changelog(extension: ChangelogPluginExtension) {
                 when (this) {
                     extension.unreleasedTerm -> this
                     else -> split("""[^-+.0-9a-zA-Z]+""".toRegex()).firstOrNull(
-                        (extension.headerParserRegex ?: semVerRegex)::matches
+                        (extension.headerParserRegex as Regex? ?: semVerRegex)::matches
                     ) ?: throw HeaderParseException(this, extension)
                 }
             }

--- a/src/main/kotlin/org/jetbrains/changelog/ChangelogPluginExtension.kt
+++ b/src/main/kotlin/org/jetbrains/changelog/ChangelogPluginExtension.kt
@@ -30,9 +30,16 @@ open class ChangelogPluginExtension(private val project: Project) {
 
     @Optional
     @Internal
-    private val headerParserRegexProperty: Property<Regex?> = project.objects.property(Regex::class.java)
+    private val headerParserRegexProperty: Property<Any?> = project.objects.property(Any::class.java)
     var headerParserRegex: Regex?
-        get() = headerParserRegexProperty.orNull
+        get() {
+            val value = headerParserRegexProperty.orNull ?: return null
+            return when (value) {
+                is Regex -> value
+                is String -> value.toRegex()
+                else -> error("String or Regex object expected for 'headerParserRegex', but got ${value.javaClass}")
+            }
+        }
         set(value) = headerParserRegexProperty.set(value)
 
     @Optional

--- a/src/main/kotlin/org/jetbrains/changelog/ChangelogPluginExtension.kt
+++ b/src/main/kotlin/org/jetbrains/changelog/ChangelogPluginExtension.kt
@@ -6,6 +6,7 @@ import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
+import java.util.regex.Pattern
 
 @Suppress("UnstableApiUsage")
 open class ChangelogPluginExtension(private val project: Project) {
@@ -30,17 +31,17 @@ open class ChangelogPluginExtension(private val project: Project) {
 
     @Optional
     @Internal
-    private val headerParserRegexProperty: Property<Any?> = project.objects.property(Any::class.java)
-    var headerParserRegex: Regex?
-        get() {
-            val value = headerParserRegexProperty.orNull ?: return null
-            return when (value) {
-                is Regex -> value
-                is String -> value.toRegex()
-                else -> error("String or Regex object expected for 'headerParserRegex', but got ${value.javaClass}")
-            }
-        }
-        set(value) = headerParserRegexProperty.set(value)
+    private val headerParserRegexProperty: Property<Regex?> = project.objects.property(Regex::class.java)
+    var headerParserRegex: Any?
+        get() = headerParserRegexProperty.orNull
+        set(value) = headerParserRegexProperty.set(headerParserRegexHelper(value))
+
+    private fun <T> headerParserRegexHelper(t: T) = when (t) {
+        is Regex -> t
+        is String -> t.toRegex()
+        is Pattern -> t.toRegex()
+        else -> throw IllegalArgumentException()
+    }
 
     @Optional
     @Internal

--- a/src/test/kotlin/org/jetbrains/changelog/BaseTest.kt
+++ b/src/test/kotlin/org/jetbrains/changelog/BaseTest.kt
@@ -47,9 +47,15 @@ open class BaseTest {
         extension = project.extensions.getByType(ChangelogPluginExtension::class.java)
     }
 
-    protected fun runTask(taskName: String, vararg arguments: String): BuildResult = GradleRunner.create()
-        .withProjectDir(project.projectDir)
-        .withArguments(taskName, "--console=plain", "--stacktrace", *arguments)
-        .withPluginClasspath()
-        .build()
+    private fun prepareTask(taskName: String, vararg arguments: String) =
+        GradleRunner.create()
+            .withProjectDir(project.projectDir)
+            .withArguments(taskName, "--console=plain", "--stacktrace", *arguments)
+            .withPluginClasspath()
+
+    protected fun runTask(taskName: String, vararg arguments: String): BuildResult =
+        prepareTask(taskName, *arguments).build()
+
+    protected fun runFailingTask(taskName: String, vararg arguments: String): BuildResult =
+        prepareTask(taskName, *arguments).buildAndFail()
 }

--- a/src/test/kotlin/org/jetbrains/changelog/ChangelogPluginExtensionTest.kt
+++ b/src/test/kotlin/org/jetbrains/changelog/ChangelogPluginExtensionTest.kt
@@ -433,8 +433,6 @@ class ChangelogPluginExtensionTest : BaseTest() {
 
     @Test
     fun `allows to customize the header parser regex to match version in different format than semver`() {
-        extension.headerParserRegex =
-            """\d+\.\d+""".toRegex()
         changelog =
             """
             # My Changelog
@@ -444,6 +442,20 @@ class ChangelogPluginExtensionTest : BaseTest() {
             * Foo
             """
 
+        extension.headerParserRegex =
+            """\d+\.\d+""".toRegex()
         assertNotNull(extension.get("2020.1"))
+
+        extension.headerParserRegex = "\\d+\\.\\d+"
+        assertNotNull(extension.get("2020.1"))
+
+        extension.headerParserRegex =
+            """\d+\.\d+""".toPattern()
+        assertNotNull(extension.get("2020.1"))
+
+        assertFailsWith<IllegalArgumentException> {
+            extension.headerParserRegex = 123
+            assertNotNull(extension.get("2020.1"))
+        }
     }
 }

--- a/src/test/kotlin/org/jetbrains/changelog/tasks/GetChangelogTaskTest.kt
+++ b/src/test/kotlin/org/jetbrains/changelog/tasks/GetChangelogTaskTest.kt
@@ -72,4 +72,58 @@ class GetChangelogTaskTest : BaseTest() {
             result.output.trim()
         )
     }
+
+    @Test
+    fun `returns change notes with Pattern set to headerParserRegex`() {
+        buildFile =
+            """
+            plugins {
+                id 'org.jetbrains.changelog'
+            }
+            changelog {
+                version = "1.0.0"
+                headerParserRegex = ~/\d\.\d\.\d/
+            }
+            """
+
+        project.evaluate()
+
+        runTask("getChangelog")
+    }
+
+    @Test
+    fun `returns change notes with String set to headerParserRegex`() {
+        buildFile =
+            """
+            plugins {
+                id 'org.jetbrains.changelog'
+            }
+            changelog {
+                version = "1.0.0"
+                headerParserRegex = "\\d\\.\\d\\.\\d"
+            }
+            """
+
+        project.evaluate()
+
+        runTask("getChangelog")
+    }
+
+    @Test
+    fun `fails with Integer set to headerParserRegex`() {
+        buildFile =
+            """
+            plugins {
+                id 'org.jetbrains.changelog'
+            }
+            changelog {
+                version = "1.0.0"
+                headerParserRegex = 123
+            }
+            """
+
+        project.evaluate()
+
+        runFailingTask("getChangelog")
+    }
 }


### PR DESCRIPTION
Hi! In continuation of https://github.com/JetBrains/gradle-changelog-plugin/issues/11

In my opinion `new Regex` doesn't look really "declarative" for Gradle configuration. I suggest to add smart processing of 'headerParserRegex' property: if this property is a regex - leave it as it is. If it's a string - convert it to the regex.

Unfortunately, I wasn't able to find a test that uses `headerParserRegexProperty` directly.