### PR TITLE
Add possibility to format the changelog in slack-specific markdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,7 @@
 
 ## [Unreleased]
 ### Added
-
-### Changed
-
-### Deprecated
-
-### Removed
-
-### Fixed
+- `toSlack()` method to generate the changelog using the slack-specific markdown
 
 ### Security
 ## [0.6.2]

--- a/README.md
+++ b/README.md
@@ -315,15 +315,16 @@ It provides a couple of properties and methods that allow altering the output fo
 
 ### Methods
 
-| Name                | Description                    | Returned type |
-| ------------------- | ------------------------------ | ------------- |
-| `noHeader()`        | Excludes header part.          | `this`        |
-| `noHeader(Boolean)` | Includes/excludes header part. | `this`        |
-| `getHeader()`       | Returns header text.           | `String`      |
-| `toText()`          | Generates Markdown output.     | `String`      |
-| `toPlainText()`     | Generates Plain Text output.   | `String`      |
-| `toString()`        | Generates Markdown output.     | `String`      |
-| `toHTML()`          | Generates HTML output.         | `String`      |
+| Name                | Description                       | Returned type |
+| ------------------- | --------------------------------- | ------------- |
+| `noHeader()`        | Excludes header part.             | `this`        |
+| `noHeader(Boolean)` | Includes/excludes header part.    | `this`        |
+| `getHeader()`       | Returns header text.              | `String`      |
+| `toText()`          | Generates Markdown output.        | `String`      |
+| `toPlainText()`     | Generates Plain Text output.      | `String`      |
+| `toString()`        | Generates Markdown output.        | `String`      |
+| `toHTML()`          | Generates HTML output.            | `String`      |
+| `toSlack()`         | Generates Slack Markdown output.  | `String`      |
 
 ## Gradle Closure in Kotlin DSL
 
@@ -349,6 +350,7 @@ closure { changelog.get() }
 | `date(pattern: String = "yyyy-MM-dd")` | Shorthand for retrieving the current date in the given format. | `String`      |
 | `markdownToHTML(input: String)`        | Converts given Markdown content to HTML output.                | `String`      |
 | `markdownToPlainText(input: String)`   | Converts given Markdown content to Plain Text output.          | `String`      |
+| `markdownToSlack(input: String)`       | Converts given Markdown content to Slack Markdown output.      | `String`      |
 
 
 ## Usage Examples

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,6 +22,7 @@ repositories {
     mavenCentral()
     jcenter()
     maven("https://dl.bintray.com/jetbrains/markdown")
+    maven("https://jitpack.io")
 }
 
 dependencies {
@@ -30,6 +31,7 @@ dependencies {
     implementation(kotlin("stdlib-jdk8"))
     implementation("org.jetbrains:markdown:0.1.45")
     implementation("org.jetbrains.kotlinx:kotlinx-html-assembly:0.7.2")
+    implementation("com.github.AlexPl292:mark-down-to-slack:1.0.1")
     detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.14.1")
     testImplementation(kotlin("test"))
     testImplementation(kotlin("test-junit"))

--- a/src/main/kotlin/org/jetbrains/changelog/Changelog.kt
+++ b/src/main/kotlin/org/jetbrains/changelog/Changelog.kt
@@ -110,6 +110,8 @@ class Changelog(extension: ChangelogPluginExtension) {
 
         fun toPlainText() = markdownToPlainText(toText())
 
+        fun toSlack() = markdownToSlack(toText())
+
         override fun toString() = toText()
     }
 

--- a/src/main/kotlin/org/jetbrains/changelog/extensions.kt
+++ b/src/main/kotlin/org/jetbrains/changelog/extensions.kt
@@ -1,5 +1,6 @@
 package org.jetbrains.changelog
 
+import dev.feedforward.markdownto.DownParser
 import groovy.lang.Closure
 import org.intellij.markdown.html.HtmlGenerator
 import org.intellij.markdown.parser.MarkdownParser
@@ -24,3 +25,5 @@ fun markdownToPlainText(input: String) = PlainTextFlavourDescriptor().run {
     HtmlGenerator(input, MarkdownParser(this).buildMarkdownTreeFromString(input), this, false)
         .generateHtml(PlainTextTagRenderer())
 }
+
+fun markdownToSlack(input: String) = DownParser(input).toSlack().toString()

--- a/src/test/kotlin/org/jetbrains/changelog/ChangelogPluginExtensionTest.kt
+++ b/src/test/kotlin/org/jetbrains/changelog/ChangelogPluginExtensionTest.kt
@@ -74,6 +74,13 @@ class ChangelogPluginExtensionTest : BaseTest() {
                 """.trimIndent(),
                 toHTML()
             )
+            assertEquals(
+                """
+                *Removed*
+                • Bar
+                """.trimIndent(),
+                toSlack()
+            )
         }
     }
 
@@ -207,6 +214,26 @@ class ChangelogPluginExtensionTest : BaseTest() {
                 """.trimIndent(),
                 toPlainText()
             )
+            assertEquals(
+                """
+                *[1.0.0]*
+                *Added*
+                • Foo _FOO_ foo
+                • Bar *BAR* bar
+                • Test <https://www.example.org|link> test
+                • Code `block` code
+                • Bravo
+                • Alpha
+                
+                *Fixed*
+                • Hello
+                • World
+                
+                *Removed*
+                • Hola
+                """.trimIndent(),
+                toSlack()
+            )
         }
     }
 
@@ -266,6 +293,18 @@ class ChangelogPluginExtensionTest : BaseTest() {
                     <ul><li>World</li></ul>
                     """.trimIndent(),
                     toHTML()
+                )
+                assertEquals(
+                    """
+                    *Added*
+                    • Foo
+                    • Buz
+                    • Alpha
+
+                    *Fixed*
+                    • World
+                    """.trimIndent(),
+                    toSlack()
                 )
             }
         }
@@ -334,6 +373,13 @@ class ChangelogPluginExtensionTest : BaseTest() {
                 <ul><li>Foo</li></ul>
                 """.trimIndent(),
                 toHTML()
+            )
+            assertEquals(
+                """
+                *[1.0.0]*
+                • Foo
+                """.trimIndent(),
+                toSlack()
             )
         }
     }


### PR DESCRIPTION
In IdeaVim project we use this plugin (and used to use hand-hacked script before this plugin was created) to send the changelog to the slack. Unfortunately, Slack uses some sort of fancy markdown, so the normal markdown doesn't render properly.
I've created a small lib that converts GitHub markdown into the Slack-specific markdown and I think it would be convenient to include it to this project.
There is also an option to create a separate gradle plugin (or anything else) that converts GH markdown to slack markdown and use it separately from this plugin, but I think that this would be more convenient to have everything in one place.