### PR TITLE
Fix `version` not being transformed to `String`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,14 @@ jobs:
   test:
     name: Test
     needs: gradleValidation
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: windows-latest
+          - os: ubuntu-latest
+          - os: macos-latest
+
     steps:
 
       - name: Setup Java

--- a/src/main/kotlin/org/jetbrains/changelog/ChangelogPluginExtension.kt
+++ b/src/main/kotlin/org/jetbrains/changelog/ChangelogPluginExtension.kt
@@ -11,7 +11,7 @@ import java.util.regex.Pattern
 open class ChangelogPluginExtension(
     objects: ObjectFactory,
     private val projectDir: File,
-    private val projectVersion: String,
+    private val projectVersion: Any,
 ) {
 
     @Optional
@@ -85,7 +85,7 @@ open class ChangelogPluginExtension(
     @Optional
     @Internal
     private val versionProperty = objects.property(String::class.java).apply {
-        set(projectVersion)
+        set("$projectVersion")
     }
     var version: String
         get() = versionProperty.get()

--- a/src/test/kotlin/org/jetbrains/changelog/ChangelogPluginTest.kt
+++ b/src/test/kotlin/org/jetbrains/changelog/ChangelogPluginTest.kt
@@ -28,7 +28,7 @@ class ChangelogPluginTest : BaseTest() {
 
         (project.tasks.findByName("getChangelog") as GetChangelogTask).apply {
             assertNotNull(this)
-            assertEquals("${project.projectDir}${File.separatorChar}CHANGELOG.md", getInputFile().path)
+            assertEquals(File("${project.projectDir}/CHANGELOG.md").path, getInputFile().path)
         }
 
         (project.tasks.findByName("patchChangelog") as PatchChangelogTask).apply {

--- a/src/test/kotlin/org/jetbrains/changelog/ChangelogPluginTest.kt
+++ b/src/test/kotlin/org/jetbrains/changelog/ChangelogPluginTest.kt
@@ -3,6 +3,7 @@ package org.jetbrains.changelog
 import org.jetbrains.changelog.tasks.GetChangelogTask
 import org.jetbrains.changelog.tasks.InitializeChangelogTask
 import org.jetbrains.changelog.tasks.PatchChangelogTask
+import java.io.File
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -27,7 +28,7 @@ class ChangelogPluginTest : BaseTest() {
 
         (project.tasks.findByName("getChangelog") as GetChangelogTask).apply {
             assertNotNull(this)
-            assertEquals("${project.projectDir}/CHANGELOG.md", getInputFile().path)
+            assertEquals("${project.projectDir}${File.separatorChar}CHANGELOG.md", getInputFile().path)
         }
 
         (project.tasks.findByName("patchChangelog") as PatchChangelogTask).apply {

--- a/src/test/kotlin/org/jetbrains/changelog/tasks/InitializeChangelogTaskTest.kt
+++ b/src/test/kotlin/org/jetbrains/changelog/tasks/InitializeChangelogTaskTest.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.changelog.tasks
 
 import org.jetbrains.changelog.BaseTest
+import java.io.File
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -94,14 +95,14 @@ class InitializeChangelogTaskTest : BaseTest() {
             }
             changelog {
                 version = "1.0.0"
-                path = "${project.projectDir}/CHANGES.md"
+                path = "${File("${project.projectDir}/CHANGES.md").path.replace("\\", "\\\\")}"
                 itemPrefix = "*"
                 unreleasedTerm = "Upcoming version"
                 groups = ["Added", "Removed"]
             }
             """
         extension.apply {
-            path = "${project.projectDir}/CHANGES.md"
+            path = File("${project.projectDir}/CHANGES.md").path
             unreleasedTerm = "Upcoming version"
             itemPrefix = "*"
         }

--- a/src/test/kotlin/org/jetbrains/changelog/tasks/PatchChangelogTaskTest.kt
+++ b/src/test/kotlin/org/jetbrains/changelog/tasks/PatchChangelogTaskTest.kt
@@ -225,7 +225,7 @@ class PatchChangelogTaskTest : BaseTest() {
             """
 
         project.evaluate()
-        val result = runTask("patchChangelog")
+        runTask("patchChangelog")
 
         assertEquals(
             """


### PR DESCRIPTION
Fix https://github.com/JetBrains/gradle-changelog-plugin/issues/26

Reckon plugin is not using a `String` type for `project.version`, but using `println(project.version)` prints a perfect semantic version.

Indeed, `project.version` type is `Any`, so I changed the `projectVersion` type to `Any` and it will be set as `String` later.

I think transforming it to a `String` in the Changelog plugin is not a problem because if the `version: Any` passed to `ChangelogPluginExtension` constructor is a not semantic version it should fail with `semVerRegex`.

Additionally, I fixed a few tests that were failing on Windows.