### PR TITLE
minor fix in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ $ ./gradlew getChangelog --console=plain -q --no-header
 #### Examples
 
 ```bash
-$ ./gradlew patchChangelog --release-note=- Foo
+$ ./gradlew patchChangelog --release-note='- Foo'
 $ cat CHANGELOG.md
 
 ## [Unreleased]


### PR DESCRIPTION
If you executed the line in that example, you would get: "Task 'Foo' not found in root project 'gradle-changelog-plugin'."