### PR TITLE
update groovy usage in README.md to work with 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ changelog {
 **build.gradle** (Groovy)
 
 ```groovy
-import java.text.SimpleDateFormat
+import org.jetbrains.changelog.Changelog
 import org.jetbrains.changelog.ChangelogSectionUrlBuilder
 import org.jetbrains.changelog.ExtensionsKt
 
@@ -112,7 +112,7 @@ intellij {
     // ...
 
     patchPluginXml {
-        changeNotes = {
+        changeNotes = provider {
             changelog.renderItem(
                 changelog
                     .getUnreleased()
@@ -126,8 +126,8 @@ intellij {
 
 changelog {
     version = "1.0.0"
-    path = file("CHANGELOG.md").cannonicalPath
-    header = "[${-> version.get()}] - ${new SimpleDateFormat("yyyy-MM-dd").format(new Date())}"
+    path = file("CHANGELOG.md").canonicalPath
+    header = "[${-> version.get()}] - ${ExtensionsKt.date("yyyy-MM-dd")}"
     headerParserRegex = ~/(\d+\.\d+)/
     introduction = """
         My awesome project that provides a lot of useful features, like:


### PR DESCRIPTION
# Pull Request Details

update README.md groovy usage to actually work with 2.0.0

## Description

- changed, SimpleDateFormat to ExtensionsKt.date, otherwise the import is not used.

- removed, import for SimpleDateFormat

- added, import for Changelog, otherwise get errors on Changelog.OutputType.HTML

- added, `provider` before brace in changeNotes assignment, otherwise get errors

- fixed, typo for file().cannonicalPath, otherwise get error: unknown method.

## Motivation and Context

The usage example in README.md for groovy does not work and results in multiple errors in the build script.

