### PR TITLE
Add --no-empty-sections flag to getChangelog task.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- Add `--no-empty-sections` flag to `getChangelog` task. [#167](../../issues/167)
+
 ## [2.0.0] - 2022-10-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -197,13 +197,14 @@ Retrieves changelog for the specified version.
 
 #### Options
 
-| Option         | Type      | Default value | Description                                        |
-|----------------|-----------|---------------|----------------------------------------------------|
-| `--no-header`  | `Boolean` | `false`       | Omits the section header in the changelog output.  |
-| `--no-summary` | `Boolean` | `false`       | Omits the section summary in the changelog output. |
-| `--no-links`   | `Boolean` | `false`       | Omits links in the changelog output.               |
-| `--version`    | `String?` | `null`        | Returns change notes for the specified version.    |
-| `--unreleased` | `Boolean` | `false`       | Returns change notes for an unreleased section.    |
+| Option                | Type      | Default value | Description                                        |
+|-----------------------|-----------|---------------|----------------------------------------------------|
+| `--no-header`         | `Boolean` | `false`       | Omits the section header in the changelog output.  |
+| `--no-summary`        | `Boolean` | `false`       | Omits the section summary in the changelog output. |
+| `--no-links`          | `Boolean` | `false`       | Omits links in the changelog output.               |
+| `--no-empty-sections` | `Boolean` | `false`       | Omits empty sections in the changelog output.      |
+| `--version`           | `String?` | `null`        | Returns change notes for the specified version.    |
+| `--unreleased`        | `Boolean` | `false`       | Returns change notes for an unreleased section.    |
 
 #### Examples
 

--- a/src/main/kotlin/org/jetbrains/changelog/tasks/GetChangelogTask.kt
+++ b/src/main/kotlin/org/jetbrains/changelog/tasks/GetChangelogTask.kt
@@ -54,6 +54,18 @@ abstract class GetChangelogTask : BaseChangelogTask() {
     var noLinks = false
 
     /**
+     * Omits empty sections in the changelog output.
+     *
+     * Default value: `false`
+     */
+    @get:Input
+    @Option(
+        option = "no-empty-sections",
+        description = "Omits empty sections in the changelog output.",
+    )
+    var noEmptySections = false
+
+    /**
      * Returns change notes for the specified version.
      *
      * Default value: `null`
@@ -101,6 +113,7 @@ abstract class GetChangelogTask : BaseChangelogTask() {
                 .withSummary(!noSummary)
                 .withLinks(!noLinks)
                 .withLinkedHeader(!noLinks)
+                .withEmptySections(!noEmptySections)
                 .let { renderItem(it, Changelog.OutputType.MARKDOWN) }
         }
     )

--- a/src/test/kotlin/org/jetbrains/changelog/tasks/GetChangelogTaskTest.kt
+++ b/src/test/kotlin/org/jetbrains/changelog/tasks/GetChangelogTaskTest.kt
@@ -20,6 +20,11 @@ class GetChangelogTaskTest : BaseTest() {
             
             - bar
             
+            ### Added
+            
+            ### Fixed
+            - I fixed myself a beverage.
+            
             ## [1.0.1] - 2022-10-17
             Release with bugfix.
             
@@ -79,6 +84,30 @@ class GetChangelogTaskTest : BaseTest() {
             
             - bar
             
+            ### Added
+            
+            ### Fixed
+            - I fixed myself a beverage.
+            
+            [Unreleased]: https://jetbrians.com/Unreleased
+            """.trimIndent(),
+            result.output
+        )
+    }
+
+    fun `returns the Unreleased change notes without empty sections`() {
+        val result = runTask(GET_CHANGELOG_TASK_NAME, "--quiet", "--unreleased", "--no-empty-sections")
+
+        assertMarkdown(
+            """
+            ## [Unreleased]
+            Some unreleased changes.
+            
+            - bar
+            
+            ### Fixed
+            - I fixed myself a beverage.
+            
             [Unreleased]: https://jetbrians.com/Unreleased
             """.trimIndent(),
             result.output
@@ -136,7 +165,7 @@ class GetChangelogTaskTest : BaseTest() {
             result.output
         )
     }
-    
+
     @Test
     fun `returns change notes without links for the latest released version`() {
         val result = runTask(GET_CHANGELOG_TASK_NAME, "--quiet", "--no-links")


### PR DESCRIPTION
# Pull Request Details

Add `--no-empty-sections` flag to `getChangelog` task.

## Description

Add `--no-empty-sections` flag to `getChangelog` task. This flag omits empty sections from the output of `getChangelog`.

## Related Issue

https://github.com/JetBrains/gradle-changelog-plugin/issues/167

## Motivation and Context

See https://github.com/JetBrains/gradle-changelog-plugin/issues/167 for description and details.

## How Has This Been Tested

- [x] Added unit test
- [x] Tested locally via local maven release in one of my OSS projects; see output below:
```
┌─(ChrisCarini)──(2023-04-29 @ 22:50:16)──( ~/GitHub/jetbrains/plugins/sample-intellij-plugin  (main) ) 
└─$ > ./gradlew getChangelog --unreleased --no-header --no-links --no-empty-sections --console=plain -q 
### Changed
- Upgrading IntelliJ from 2023.1 to 2023.1.1

### Deprecated
- Deprecated line


┌─(ChrisCarini)──(2023-04-29 @ 22:50:19)──( ~/GitHub/jetbrains/plugins/sample-intellij-plugin  (main) ) 
└─$ >
```
**...vs...**
```
┌─(ChrisCarini)──(2023-04-29 @ 22:50:19)──( ~/GitHub/jetbrains/plugins/sample-intellij-plugin  (main) ) 
└─$ > ./gradlew getChangelog --unreleased --no-header --no-links --console=plain -q 
### Added

### Changed
- Upgrading IntelliJ from 2023.1 to 2023.1.1

### Deprecated
- Deprecated line

### Removed

### Fixed

### Security


┌─(ChrisCarini)──(2023-04-29 @ 22:50:28)──( ~/GitHub/jetbrains/plugins/sample-intellij-plugin  (main) ) 
└─$ > 
```

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the [**README**](README.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
