### PR TITLE
Fix wrong markdown render of changelog that use CRLF or CR line separator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- Wrong markdown render of changelog that use CRLF or CR line separator [#176](../../issues/176)
+
 ## [2.1.0] - 2023-06-02
 
 ### Added

--- a/src/main/kotlin/org/jetbrains/changelog/ChangelogPlugin.kt
+++ b/src/main/kotlin/org/jetbrains/changelog/ChangelogPlugin.kt
@@ -101,7 +101,7 @@ class ChangelogPlugin : Plugin<Project> {
                             if (!exists()) {
                                 createNewFile()
                             }
-                            readText()
+                            readText().normalizeToLineFeed()
                         }
                     }.get(),
                     defaultPreTitle = preTitle.orNull,

--- a/src/main/kotlin/org/jetbrains/changelog/extensions.kt
+++ b/src/main/kotlin/org/jetbrains/changelog/extensions.kt
@@ -39,6 +39,17 @@ internal fun String.reformat(lineSeparator: String): String {
     }
 }
 
+internal fun String.normalizeToLineFeed(): String {
+    val result = listOf(
+        "\r\n" to "\n",
+        "\r" to "\n",
+    ).fold(this) { acc, (pattern, replacement) ->
+        acc.replace(pattern, replacement)
+    }
+
+    return result
+}
+
 fun interface ChangelogSectionUrlBuilder {
     fun build(repositoryUrl: String, currentVersion: String?, previousVersion: String?, isUnreleased: Boolean): String
 }

--- a/src/test/kotlin/org/jetbrains/changelog/BaseTest.kt
+++ b/src/test/kotlin/org/jetbrains/changelog/BaseTest.kt
@@ -36,7 +36,7 @@ open class BaseTest {
             field = value
             changelogFile.run {
                 createNewFile()
-                writeText(value.trimIndent().trim())
+                writeText(value)
             }
         }
         get() = changelogFile.readText()

--- a/src/test/kotlin/org/jetbrains/changelog/ExtensionsTest.kt
+++ b/src/test/kotlin/org/jetbrains/changelog/ExtensionsTest.kt
@@ -76,4 +76,45 @@ class ExtensionsTest {
             """.trimIndent().reformat(lineSeparator)
         )
     }
+
+    @Test
+    fun `normalize string to line feed`() {
+        val text = """
+            Pre title content.
+            
+            # Title
+            Summary
+            
+            ## [Unreleased]
+            
+            ## [1.0.0]
+            - asd
+            
+            ## [0.1.0]
+            
+            ### Added
+            - Buz
+            
+            """.trimIndent()
+
+        assertEquals(
+            text,
+            text.replace("\n", "\r\n").normalizeToLineFeed()
+        )
+
+        assertEquals(
+            text,
+            text.replace("\n", "\r").normalizeToLineFeed()
+        )
+
+        assertEquals(
+            text,
+            text.normalizeToLineFeed()
+        )
+
+        assertEquals(
+            "text\ntext2\ntext3\ntext4",
+            "text\ntext2\rtext3\r\ntext4".normalizeToLineFeed()
+        )
+    }
 }

--- a/src/test/kotlin/org/jetbrains/changelog/tasks/GetChangelogTaskTest.kt
+++ b/src/test/kotlin/org/jetbrains/changelog/tasks/GetChangelogTaskTest.kt
@@ -95,6 +95,7 @@ class GetChangelogTaskTest : BaseTest() {
         )
     }
 
+    @Test
     fun `returns the Unreleased change notes without empty sections`() {
         val result = runTask(GET_CHANGELOG_TASK_NAME, "--quiet", "--unreleased", "--no-empty-sections")
 
@@ -260,5 +261,101 @@ class GetChangelogTaskTest : BaseTest() {
         val result = runTask(GET_CHANGELOG_TASK_NAME)
 
         assertTrue(result.output.contains("Reusing configuration cache."))
+    }
+
+    @Test
+    fun `get changelog with CRLF line separator`() {
+        changelog =
+            """
+            # Changelog
+            ## [Unreleased]
+            Some unreleased changes.
+            
+            - bar
+            
+            ### Added
+            
+            ### Fixed
+            - I fixed myself a beverage.
+            
+            ## [1.0.1] - 2022-10-17
+            Release with bugfix.
+            
+            ### Fixed
+            - bar
+            
+            ## [1.0.0] - 2022-10-10
+            That was a great release.
+            
+            ### Added
+            - foo
+            
+            [Unreleased]: https://jetbrians.com/Unreleased
+            [1.0.1]: https://jetbrians.com/1.0.1
+            [1.0.0]: https://jetbrians.com/1.0.0
+            """.trimIndent().replace("\n", "\r\n")
+
+        val result = runTask(GET_CHANGELOG_TASK_NAME, "--quiet")
+
+        assertMarkdown(
+            """
+            ## [1.0.1] - 2022-10-17
+            Release with bugfix.
+            
+            ### Fixed
+            - bar
+            
+            [1.0.1]: https://jetbrians.com/1.0.1
+            """.trimIndent().replace("\n", "\r\n"),
+            result.output
+        )
+    }
+
+    @Test
+    fun `get changelog with CR line separator`() {
+        changelog =
+            """
+            # Changelog
+            ## [Unreleased]
+            Some unreleased changes.
+            
+            - bar
+            
+            ### Added
+            
+            ### Fixed
+            - I fixed myself a beverage.
+            
+            ## [1.0.1] - 2022-10-17
+            Release with bugfix.
+            
+            ### Fixed
+            - bar
+            
+            ## [1.0.0] - 2022-10-10
+            That was a great release.
+            
+            ### Added
+            - foo
+            
+            [Unreleased]: https://jetbrians.com/Unreleased
+            [1.0.1]: https://jetbrians.com/1.0.1
+            [1.0.0]: https://jetbrians.com/1.0.0
+            """.trimIndent().replace("\n", "\r")
+
+        val result = runTask(GET_CHANGELOG_TASK_NAME, "--quiet")
+
+        assertMarkdown(
+            """
+            ## [1.0.1] - 2022-10-17
+            Release with bugfix.
+            
+            ### Fixed
+            - bar
+            
+            [1.0.1]: https://jetbrians.com/1.0.1
+            """.trimIndent().replace("\n", "\r"),
+            result.output
+        )
     }
 }

--- a/src/test/kotlin/org/jetbrains/changelog/tasks/InitializeChangelogTaskTest.kt
+++ b/src/test/kotlin/org/jetbrains/changelog/tasks/InitializeChangelogTaskTest.kt
@@ -181,4 +181,102 @@ class InitializeChangelogTaskTest : BaseTest() {
 
         assertTrue(result.output.contains("Reusing configuration cache."))
     }
+
+    @Test
+    fun `creates new changelog file with CRLF line separator`() {
+        extension.lineSeparator.set("\r\n")
+
+        runTask(INITIALIZE_CHANGELOG_TASK_NAME)
+
+        assertMarkdown(
+            """
+            # Changelog
+            
+            ## Unreleased
+            
+            ### Added
+            
+            ### Changed
+            
+            ### Deprecated
+            
+            ### Removed
+            
+            ### Fixed
+            
+            ### Security
+
+            """.trimIndent().replace("\n", "\r\n"),
+            extension.render()
+        )
+
+        assertMarkdown(
+            """
+            ## Unreleased
+            
+            ### Added
+            
+            ### Changed
+            
+            ### Deprecated
+            
+            ### Removed
+            
+            ### Fixed
+            
+            ### Security
+            
+            """.trimIndent().replace("\n", "\r\n"),
+            extension.renderItem(extension.getUnreleased())
+        )
+    }
+
+    @Test
+    fun `creates new changelog file with CR line separator`() {
+        extension.lineSeparator.set("\r")
+
+        runTask(INITIALIZE_CHANGELOG_TASK_NAME)
+
+        assertMarkdown(
+            """
+            # Changelog
+            
+            ## Unreleased
+            
+            ### Added
+            
+            ### Changed
+            
+            ### Deprecated
+            
+            ### Removed
+            
+            ### Fixed
+            
+            ### Security
+
+            """.trimIndent().replace("\n", "\r"),
+            extension.render()
+        )
+
+        assertMarkdown(
+            """
+            ## Unreleased
+            
+            ### Added
+            
+            ### Changed
+            
+            ### Deprecated
+            
+            ### Removed
+            
+            ### Fixed
+            
+            ### Security
+            
+            """.trimIndent().replace("\n", "\r"),
+            extension.renderItem(extension.getUnreleased())
+        )
+    }
 }

--- a/src/test/kotlin/org/jetbrains/changelog/tasks/PatchChangelogTaskTest.kt
+++ b/src/test/kotlin/org/jetbrains/changelog/tasks/PatchChangelogTaskTest.kt
@@ -1181,4 +1181,88 @@ class PatchChangelogTaskTest : BaseTest() {
 
         assertTrue(result.output.contains("Reusing configuration cache."))
     }
+
+    @Test
+    fun `patch with CRLF line separator`() {
+        changelog =
+            """
+            <!-- Foo bar -->
+            
+            # Changelog
+            My project changelog.
+            
+            ## [Unreleased]
+            Fancy release.
+            
+            ### Added
+            - foo
+            
+            ### Changed
+            - changed
+            - changed 2
+            """.trimIndent().replace("\n", "\r\n")
+
+        project.evaluate()
+        runTask(PATCH_CHANGELOG_TASK_NAME)
+
+        assertMarkdown(
+            """
+            ## [1.0.0] - $date
+            Fancy release.
+            
+            ### Added
+            - foo
+            
+            ### Changed
+            - changed
+            - changed 2
+            
+            [1.0.0]: https://github.com/JetBrains/gradle-changelog-plugin/commits/v1.0.0
+            
+            """.trimIndent().replace("\n", "\r\n"),
+            extension.renderItem(extension.get(version))
+        )
+    }
+
+    @Test
+    fun `patch with CR line separator`() {
+        changelog =
+            """
+            <!-- Foo bar -->
+            
+            # Changelog
+            My project changelog.
+            
+            ## [Unreleased]
+            Fancy release.
+            
+            ### Added
+            - foo
+            
+            ### Changed
+            - changed
+            - changed 2
+            """.trimIndent().replace("\n", "\r")
+
+        project.evaluate()
+        runTask(PATCH_CHANGELOG_TASK_NAME)
+
+        assertMarkdown(
+            """
+            ## [1.0.0] - $date
+            Fancy release.
+            
+            ### Added
+            - foo
+            
+            ### Changed
+            - changed
+            - changed 2
+            
+            [1.0.0]: https://github.com/JetBrains/gradle-changelog-plugin/commits/v1.0.0
+            
+            """.trimIndent().replace("\n", "\r"),
+            extension.renderItem(extension.get(version))
+        )
+    }
 }


### PR DESCRIPTION
# Pull Request Details

This pull request should fix #176, and takes support to all line separator. In this moment, the only (real) supported line separator is only the Unix/MacOS `LF` line separator.

## Description

This PR fix `gradle patchChangelog` task if `CHANGELOG.md` use `CRLF` or `CR` line separator, and also other issue on changelog that use these line separators

## Related Issue

- #176 

## Motivation and Context

This PR takes support to all line separators and applies a workaround to a [markdown component](https://github.com/JetBrains/markdown/issues/49),  that is open since 2020.

The solution applied is the following:
- Read `CHANGELOG.md` file content and convert line separator to LF
- Parse previous content using [markdown library](https://github.com/JetBrains/markdown), that in this moment full support only LF line separator (Caused by bug described above)
- After all operation, in various `render` method, use the already present `reformat` method that restore the correct line separator choose by user.

## How Has This Been Tested

I tested the changes on my personal gradle project that use `gradle changelog plugin`, that use a `CHANGELOG.md` file with `CRLF` line separator. I also create some unit test on my changes.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the [**README**](README.md).
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
