### PR TITLE
Ensure changelog render is consistent with all line separator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Gradle Changelog Plugin
 
 ## [Unreleased]
+### Fixed
+- Changelog render is inconsistent between different line separators [#182](../../issues/182)
 
 ## [2.1.1] - 2023-07-07
 

--- a/README.md
+++ b/README.md
@@ -427,11 +427,11 @@ It provides a couple of properties and methods that allow altering the output fo
 
 ## Helper Methods
 
-| Name                                   | Description                                                    | Returned type |
-|----------------------------------------|----------------------------------------------------------------|---------------|
-| `date(pattern: String = "yyyy-MM-dd")` | Shorthand for retrieving the current date in the given format. | `String`      |
-| `markdownToHTML(input: String)`        | Converts given Markdown content to HTML output.                | `String`      |
-| `markdownToPlainText(input: String)`   | Converts given Markdown content to Plain Text output.          | `String`      |
+| Name                                                          | Description                                                    | Returned type |
+|---------------------------------------------------------------|----------------------------------------------------------------|---------------|
+| `date(pattern: String = "yyyy-MM-dd")`                        | Shorthand for retrieving the current date in the given format. | `String`      |
+| `markdownToHTML(input: String, lineSeparator: String = "\n")` | Converts given Markdown content to HTML output.                | `String`      |
+| `markdownToPlainText(input: String, lineSeparator: String)`   | Converts given Markdown content to Plain Text output.          | `String`      |
 
 > **Note**
 >

--- a/src/main/kotlin/org/jetbrains/changelog/Changelog.kt
+++ b/src/main/kotlin/org/jetbrains/changelog/Changelog.kt
@@ -181,15 +181,7 @@ data class Changelog(
         sequence {
             if (withHeader) {
                 when {
-                    withLinkedHeader && links.containsKey(version) -> yield(
-                        "$LEVEL_2 ${
-                            header.replace(
-                                version,
-                                "[$version]"
-                            )
-                        }"
-                    )
-
+                    withLinkedHeader && links.containsKey(version) -> yield("$LEVEL_2 ${header.replace(version, "[$version]")}")
                     else -> yield("$LEVEL_2 $header")
                 }
             }

--- a/src/main/kotlin/org/jetbrains/changelog/Changelog.kt
+++ b/src/main/kotlin/org/jetbrains/changelog/Changelog.kt
@@ -119,6 +119,7 @@ data class Changelog(
                 .withEmptySections(isUnreleased)
         }
     }
+
     val links
         get() = sequence {
             repositoryUrl?.let {
@@ -180,7 +181,15 @@ data class Changelog(
         sequence {
             if (withHeader) {
                 when {
-                    withLinkedHeader && links.containsKey(version) -> yield("$LEVEL_2 ${header.replace(version, "[$version]")}")
+                    withLinkedHeader && links.containsKey(version) -> yield(
+                        "$LEVEL_2 ${
+                            header.replace(
+                                version,
+                                "[$version]"
+                            )
+                        }"
+                    )
+
                     else -> yield("$LEVEL_2 $header")
                 }
             }
@@ -412,7 +421,7 @@ data class Changelog(
     private fun String.processOutput(outputType: OutputType) = when (outputType) {
         OutputType.MARKDOWN -> this
 
-        OutputType.HTML -> markdownToHTML(this)
+        OutputType.HTML -> markdownToHTML(this, lineSeparator)
 
         OutputType.PLAIN_TEXT -> markdownToPlainText(this, lineSeparator)
     }

--- a/src/main/kotlin/org/jetbrains/changelog/Changelog.kt
+++ b/src/main/kotlin/org/jetbrains/changelog/Changelog.kt
@@ -419,10 +419,8 @@ data class Changelog(
         .trim()
 
     private fun String.processOutput(outputType: OutputType) = when (outputType) {
-        OutputType.MARKDOWN -> this
-
+        OutputType.MARKDOWN -> this.normalizeLineSeparator(lineSeparator) // Ensure that output content has always the correct line separator
         OutputType.HTML -> markdownToHTML(this, lineSeparator)
-
         OutputType.PLAIN_TEXT -> markdownToPlainText(this, lineSeparator)
     }
 

--- a/src/main/kotlin/org/jetbrains/changelog/ChangelogPlugin.kt
+++ b/src/main/kotlin/org/jetbrains/changelog/ChangelogPlugin.kt
@@ -101,7 +101,8 @@ class ChangelogPlugin : Plugin<Project> {
                             if (!exists()) {
                                 createNewFile()
                             }
-                            readText().normalizeToLineFeed()
+                            // Normalize text to LF, because markdown library currently full support only this line separator
+                            readText().normalizeLineSeparator("\n")
                         }
                     }.get(),
                     defaultPreTitle = preTitle.orNull,

--- a/src/test/kotlin/org/jetbrains/changelog/BaseTest.kt
+++ b/src/test/kotlin/org/jetbrains/changelog/BaseTest.kt
@@ -99,4 +99,8 @@ open class BaseTest {
     protected fun assertHTML(@Language("HTML") expected: String, @Language("HTML") actual: String) {
         assertEquals(expected.trim(), actual.trim())
     }
+
+    protected fun assertText(@Language("TEXT") expected: String, @Language("TEXT") actual: String) {
+        assertEquals(expected.trim(), actual.trim())
+    }
 }

--- a/src/test/kotlin/org/jetbrains/changelog/ExtensionsTest.kt
+++ b/src/test/kotlin/org/jetbrains/changelog/ExtensionsTest.kt
@@ -9,8 +9,6 @@ import kotlin.test.assertEquals
 
 class ExtensionsTest {
 
-    private val lineSeparator = "\n"
-
     @Test
     fun dateTest() {
         assertEquals(SimpleDateFormat("yyyy-MM-dd").format(Date()), date())
@@ -21,8 +19,9 @@ class ExtensionsTest {
 
     @Test
     fun `reformat changelog`() {
-        assertEquals(
-            """
+        for (lineSeparator: String in listOf("\n", "\r\n", "\r")) {
+            assertEquals(
+                """
             Pre title content.
             
             # Title
@@ -38,8 +37,8 @@ class ExtensionsTest {
             ### Added
             - Buz
             
-            """.trimIndent(),
-            """
+            """.trimIndent().normalizeLineSeparator(lineSeparator),
+                """
             Pre title content.
             # Title
             Summary
@@ -49,11 +48,12 @@ class ExtensionsTest {
             ## [0.1.0]
             ### Added
             - Buz
-            """.trimIndent().reformat(lineSeparator)
-        )
+            """.trimIndent().normalizeLineSeparator(lineSeparator).reformat(lineSeparator),
+                "reformat changelog that use $lineSeparator"
+            )
 
-        assertEquals(
-            """
+            assertEquals(
+                """
             Foo
             
             # My Title
@@ -65,16 +65,58 @@ class ExtensionsTest {
             
             ### Removed
             
-            """.trimIndent(),
-            """
+            """.trimIndent().normalizeLineSeparator(lineSeparator),
+                """
             Foo
             # My Title
             Introduction
             ## Upcoming version
             ### Added
             ### Removed
-            """.trimIndent().reformat(lineSeparator)
-        )
+            """.trimIndent().normalizeLineSeparator(lineSeparator).reformat(lineSeparator),
+                "reformat changelog that use $lineSeparator"
+            )
+
+            assertEquals(
+                """
+            Pre title content.
+            
+            # Title
+            Summary
+            
+            ## [Unreleased]
+            
+            ## [1.0.0]
+            - asd
+            
+            ## [0.1.0]
+            
+            ### Added
+            - Buz
+            
+            [Unreleased] https://jetbrains.com/unreleased
+            [1.0.0] https://jetbrains.com/1.0.0
+            [0.1.0] https://jetbrains.com/0.1.0
+            
+            """.trimIndent().normalizeLineSeparator(lineSeparator),
+                """
+            Pre title content.
+            # Title
+            Summary
+            ## [Unreleased]
+            ## [1.0.0]
+            - asd
+            ## [0.1.0]
+            ### Added
+            - Buz
+            
+            [Unreleased] https://jetbrains.com/unreleased
+            [1.0.0] https://jetbrains.com/1.0.0
+            [0.1.0] https://jetbrains.com/0.1.0
+            """.trimIndent().normalizeLineSeparator(lineSeparator).reformat(lineSeparator),
+                "reformat changelog that use $lineSeparator"
+            )
+        }
     }
 
     @Test
@@ -115,6 +157,16 @@ class ExtensionsTest {
         assertEquals(
             "text\ntext2\ntext3\ntext4",
             "text\ntext2\rtext3\r\ntext4".normalizeLineSeparator("\n")
+        )
+
+        assertEquals(
+            text.replace("\n", "\r\n"),
+            text.normalizeLineSeparator("\r\n")
+        )
+
+        assertEquals(
+            text.replace("\n", "\r"),
+            text.normalizeLineSeparator("\r")
         )
     }
 }

--- a/src/test/kotlin/org/jetbrains/changelog/ExtensionsTest.kt
+++ b/src/test/kotlin/org/jetbrains/changelog/ExtensionsTest.kt
@@ -78,7 +78,7 @@ class ExtensionsTest {
     }
 
     @Test
-    fun `normalize string to line feed`() {
+    fun `normalize string line separator`() {
         val text = """
             Pre title content.
             
@@ -99,22 +99,22 @@ class ExtensionsTest {
 
         assertEquals(
             text,
-            text.replace("\n", "\r\n").normalizeToLineFeed()
+            text.replace("\n", "\r\n").normalizeLineSeparator("\n")
         )
 
         assertEquals(
             text,
-            text.replace("\n", "\r").normalizeToLineFeed()
+            text.replace("\n", "\r").normalizeLineSeparator("\n")
         )
 
         assertEquals(
             text,
-            text.normalizeToLineFeed()
+            text.normalizeLineSeparator("\n")
         )
 
         assertEquals(
             "text\ntext2\ntext3\ntext4",
-            "text\ntext2\rtext3\r\ntext4".normalizeToLineFeed()
+            "text\ntext2\rtext3\r\ntext4".normalizeLineSeparator("\n")
         )
     }
 }

--- a/src/test/kotlin/org/jetbrains/changelog/tasks/GetChangelogTaskTest.kt
+++ b/src/test/kotlin/org/jetbrains/changelog/tasks/GetChangelogTaskTest.kt
@@ -4,6 +4,7 @@ package org.jetbrains.changelog.tasks
 
 import org.jetbrains.changelog.BaseTest
 import org.jetbrains.changelog.ChangelogPluginConstants.GET_CHANGELOG_TASK_NAME
+import org.jetbrains.changelog.normalizeLineSeparator
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertTrue
@@ -293,7 +294,7 @@ class GetChangelogTaskTest : BaseTest() {
             [Unreleased]: https://jetbrians.com/Unreleased
             [1.0.1]: https://jetbrians.com/1.0.1
             [1.0.0]: https://jetbrians.com/1.0.0
-            """.trimIndent().replace("\n", "\r\n")
+            """.trimIndent().normalizeLineSeparator("\r\n")
 
         val result = runTask(GET_CHANGELOG_TASK_NAME, "--quiet")
 
@@ -306,7 +307,7 @@ class GetChangelogTaskTest : BaseTest() {
             - bar
             
             [1.0.1]: https://jetbrians.com/1.0.1
-            """.trimIndent().replace("\n", "\r\n"),
+            """.trimIndent().normalizeLineSeparator("\r\n"),
             result.output
         )
     }
@@ -341,7 +342,7 @@ class GetChangelogTaskTest : BaseTest() {
             [Unreleased]: https://jetbrians.com/Unreleased
             [1.0.1]: https://jetbrians.com/1.0.1
             [1.0.0]: https://jetbrians.com/1.0.0
-            """.trimIndent().replace("\n", "\r")
+            """.trimIndent().normalizeLineSeparator("\r")
 
         val result = runTask(GET_CHANGELOG_TASK_NAME, "--quiet")
 
@@ -354,7 +355,7 @@ class GetChangelogTaskTest : BaseTest() {
             - bar
             
             [1.0.1]: https://jetbrians.com/1.0.1
-            """.trimIndent().replace("\n", "\r"),
+            """.trimIndent().normalizeLineSeparator("\r"),
             result.output
         )
     }

--- a/src/test/kotlin/org/jetbrains/changelog/tasks/InitializeChangelogTaskTest.kt
+++ b/src/test/kotlin/org/jetbrains/changelog/tasks/InitializeChangelogTaskTest.kt
@@ -4,6 +4,7 @@ package org.jetbrains.changelog.tasks
 
 import org.jetbrains.changelog.BaseTest
 import org.jetbrains.changelog.ChangelogPluginConstants.INITIALIZE_CHANGELOG_TASK_NAME
+import org.jetbrains.changelog.normalizeLineSeparator
 import java.io.File
 import kotlin.test.*
 
@@ -206,7 +207,7 @@ class InitializeChangelogTaskTest : BaseTest() {
             
             ### Security
 
-            """.trimIndent().replace("\n", "\r\n"),
+            """.trimIndent().normalizeLineSeparator("\r\n"),
             extension.render()
         )
 
@@ -226,7 +227,7 @@ class InitializeChangelogTaskTest : BaseTest() {
             
             ### Security
             
-            """.trimIndent().replace("\n", "\r\n"),
+            """.trimIndent().normalizeLineSeparator("\r\n"),
             extension.renderItem(extension.getUnreleased())
         )
     }
@@ -255,7 +256,7 @@ class InitializeChangelogTaskTest : BaseTest() {
             
             ### Security
 
-            """.trimIndent().replace("\n", "\r"),
+            """.trimIndent().normalizeLineSeparator("\r"),
             extension.render()
         )
 
@@ -275,7 +276,7 @@ class InitializeChangelogTaskTest : BaseTest() {
             
             ### Security
             
-            """.trimIndent().replace("\n", "\r"),
+            """.trimIndent().normalizeLineSeparator("\r"),
             extension.renderItem(extension.getUnreleased())
         )
     }

--- a/src/test/kotlin/org/jetbrains/changelog/tasks/PatchChangelogTaskTest.kt
+++ b/src/test/kotlin/org/jetbrains/changelog/tasks/PatchChangelogTaskTest.kt
@@ -5,6 +5,7 @@ package org.jetbrains.changelog.tasks
 import org.jetbrains.changelog.BaseTest
 import org.jetbrains.changelog.ChangelogPluginConstants.PATCH_CHANGELOG_TASK_NAME
 import org.jetbrains.changelog.exceptions.MissingVersionException
+import org.jetbrains.changelog.normalizeLineSeparator
 import java.text.SimpleDateFormat
 import java.util.*
 import kotlin.test.*
@@ -151,7 +152,7 @@ class PatchChangelogTaskTest : BaseTest() {
 
         assertFailsWith<MissingVersionException> {
             extension.getUnreleased().also {
-                println("it = ${it}")
+                println("it = $it")
             }
         }
     }
@@ -519,7 +520,10 @@ class PatchChangelogTaskTest : BaseTest() {
 
         project.evaluate()
 
-        runTask(PATCH_CHANGELOG_TASK_NAME, "--release-note=Foo\n\n- asd\n- Hello [world]!\n\n[world]: https://jetbrains.com")
+        runTask(
+            PATCH_CHANGELOG_TASK_NAME,
+            "--release-note=Foo\n\n- asd\n- Hello [world]!\n\n[world]: https://jetbrains.com"
+        )
 
         assertMarkdown(
             """
@@ -1200,7 +1204,7 @@ class PatchChangelogTaskTest : BaseTest() {
             ### Changed
             - changed
             - changed 2
-            """.trimIndent().replace("\n", "\r\n")
+            """.trimIndent().normalizeLineSeparator("\r\n")
 
         project.evaluate()
         runTask(PATCH_CHANGELOG_TASK_NAME)
@@ -1219,7 +1223,7 @@ class PatchChangelogTaskTest : BaseTest() {
             
             [1.0.0]: https://github.com/JetBrains/gradle-changelog-plugin/commits/v1.0.0
             
-            """.trimIndent().replace("\n", "\r\n"),
+            """.trimIndent().normalizeLineSeparator("\r\n"),
             extension.renderItem(extension.get(version))
         )
     }
@@ -1242,7 +1246,7 @@ class PatchChangelogTaskTest : BaseTest() {
             ### Changed
             - changed
             - changed 2
-            """.trimIndent().replace("\n", "\r")
+            """.trimIndent().normalizeLineSeparator("\r")
 
         project.evaluate()
         runTask(PATCH_CHANGELOG_TASK_NAME)
@@ -1261,7 +1265,7 @@ class PatchChangelogTaskTest : BaseTest() {
             
             [1.0.0]: https://github.com/JetBrains/gradle-changelog-plugin/commits/v1.0.0
             
-            """.trimIndent().replace("\n", "\r"),
+            """.trimIndent().normalizeLineSeparator("\r"),
             extension.renderItem(extension.get(version))
         )
     }

--- a/src/test/kotlin/org/jetbrains/changelog/tasks/PatchChangelogTaskTest.kt
+++ b/src/test/kotlin/org/jetbrains/changelog/tasks/PatchChangelogTaskTest.kt
@@ -1269,4 +1269,107 @@ class PatchChangelogTaskTest : BaseTest() {
             extension.renderItem(extension.get(version))
         )
     }
+
+    @Test
+    fun `patch complex file with CRLF`() {
+        changelog =
+            """
+            # Changelog
+            
+            ## [Unreleased]
+            
+            ### Changed
+            - This item has three paragraphs.
+            
+              All paragraphs should be preserved.
+            
+              Separate paragraphs must not be merged.
+            - This item contains a nested list.
+            
+              - Sub-Item 1
+              - Sub-Item 2
+            - ```
+              This item is a code block
+              ```
+            
+            ## [0.0.1] - 2022-10-10
+            
+            ### Added
+            - ```
+              A code block could also be followed by a list
+              ```
+            
+              - Sub-Item 1
+              - Sub-Item 2
+            
+              | Header                      |
+              |-----------------------------|
+              | There could also be a table |
+            
+            ### Fixed
+            - Following sections must stay unaffected.
+            
+            """.trimIndent().normalizeLineSeparator("\r\n")
+
+        runTask(PATCH_CHANGELOG_TASK_NAME)
+
+        assertMarkdown(
+            """
+            # Changelog
+            
+            ## [Unreleased]
+            
+            ### Added
+            
+            ### Changed
+            
+            ### Deprecated
+            
+            ### Removed
+            
+            ### Fixed
+            
+            ### Security
+            
+            ## [1.0.0] - $date
+            
+            ### Changed
+            - This item has three paragraphs.
+            
+              All paragraphs should be preserved.
+            
+              Separate paragraphs must not be merged.
+            - This item contains a nested list.
+            
+              - Sub-Item 1
+              - Sub-Item 2
+            - ```
+              This item is a code block
+              ```
+            
+            ## [0.0.1] - 2022-10-10
+            
+            ### Added
+            - ```
+              A code block could also be followed by a list
+              ```
+            
+              - Sub-Item 1
+              - Sub-Item 2
+            
+              | Header                      |
+              |-----------------------------|
+              | There could also be a table |
+            
+            ### Fixed
+            - Following sections must stay unaffected.
+            
+            [Unreleased]: https://github.com/JetBrains/gradle-changelog-plugin/compare/v1.0.0...HEAD
+            [1.0.0]: https://github.com/JetBrains/gradle-changelog-plugin/compare/v0.0.1...v1.0.0
+            [0.0.1]: https://github.com/JetBrains/gradle-changelog-plugin/commits/v0.0.1
+            
+            """.trimIndent().normalizeLineSeparator("\r\n"),
+            changelog
+        )
+    }
 }


### PR DESCRIPTION
# Pull Request Details

<!--- Provide a general summary of your changes in the Title above -->
This pull request should fix #182 , and ensures that changelog render is consistent with all line separator.
In this moment, `LF` line separator works properly, but instead `CRLF` and `LF` have some bugs/different behaviour.

## Description

<!--- Describe your changes in detail -->
While the purpose of PR #177 was only to fix a regresion, the goal of this PR is to ensures that changelog render is unbiased to line separator.

In particular:
- Added a new optional parameter `lineSeparator` to `markdownToHTML` helper method
- `markdownToHTML` and `markdownToPlainText` now convert line separator to `LF` before AST parsing.
- Fixed `reformat` method (Some regex work only with `\n` or `\r`, but not with `\r\n`, due to missing group)
- Added a new `assertText` method, useful for test that plain text output strings are equals (Without improperly using `assertMarkdown`)
- Ensure that `processOutput` normalize line separator also for `OutputType.MARKDOWN` (In same cases, `joinToString` and `reformat` is not enough and generate a content that contains different line separators)

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- #182 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
While the purpose of PR #177 was only to fix a regresion, the goal of this PR is to ensures that changelog render is unbiased to line separator. See also #182 to see some cases that this PR fix.

The solution applied is the same of #177, so:
- Before parsing changelog using [markdown library](https://github.com/JetBrains/markdown), convert line separator to `LF`.
- After parsing, restore the correct line separator.
but this time the behaviour is applied to all code that use the markdown library.

See also [markdown bug](https://github.com/JetBrains/markdown/issues/49)

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have added some unit test, that cover my modification. All new and existing tests passed.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the [**README**](README.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
