### PR TITLE
Fix documentation to avoid HeaderParseException

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ changelog {
     version.set("1.0.0")
     path.set(file("CHANGELOG.md").canonicalPath)
     header.set(provider { "[${version.get()}] - ${date()}" })
-    headerParserRegex.set("""(\d+\.\d+)""".toRegex())
+    headerParserRegex.set("""(\d+\.\d+\.\d+)""".toRegex())
     introduction.set(
         """
         My awesome project that provides a lot of useful features, like:
@@ -128,7 +128,7 @@ changelog {
     version = "1.0.0"
     path = file("CHANGELOG.md").canonicalPath
     header = "[${-> version.get()}] - ${ExtensionsKt.date("yyyy-MM-dd")}"
-    headerParserRegex = ~/(\d+\.\d+)/
+    headerParserRegex = ~/(\d+\.\d+\.\d+)/
     introduction = """
         My awesome project that provides a lot of useful features, like:
         


### PR DESCRIPTION
# Pull Request Details

By following the example in the doc I am getting the following exception:
```      > org.jetbrains.changelog.exceptions.HeaderParseException: Header '[[2023.10.09]] - 2023-09-10' does not contain version number. By default, SemVer format is required (i.e. 1.0.0). To use other formats, like '1.0', adjust the 'changelog.headerParserRegex' property. ```

I just changed the regex to support 3 dot sem version.


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the [**README**](README.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
