### PR TITLE
Fix sorting of versions containing hyphens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Versions containing hyphens are now sorted correctly [#171](../../issues/171)
+
 ## [2.2.0] - 2023-08-28
 
 ### Added

--- a/src/main/kotlin/org/jetbrains/changelog/Version.kt
+++ b/src/main/kotlin/org/jetbrains/changelog/Version.kt
@@ -28,8 +28,8 @@ class Version(
             .or { patch - other.patch }
             .or {
                 when {
-                    version.contains('-') -> -1
-                    other.version.contains('-') -> 1
+                    version.contains('-') && other.version.contains('-').not() -> -1
+                    other.version.contains('-') && version.contains('-').not() -> 1
                     else -> 0
                 }
             }

--- a/src/test/kotlin/org/jetbrains/changelog/tasks/PatchChangelogTaskTest.kt
+++ b/src/test/kotlin/org/jetbrains/changelog/tasks/PatchChangelogTaskTest.kt
@@ -631,6 +631,78 @@ class PatchChangelogTaskTest : BaseTest() {
     }
 
     @Test
+    fun `test sorting version links`() {
+        buildFile =
+            """
+            plugins {
+                id 'org.jetbrains.changelog'
+            }
+            changelog {
+                version = "0.9.5-alpha.3"
+                repositoryUrl = "https://github.com/JetBrains/gradle-changelog-plugin"
+            }
+            """.trimIndent()
+
+        changelog =
+            """
+            # Changelog
+            
+            ## [Unreleased]
+            
+            ### Added
+            
+            ### Fixed
+            
+            ## [0.9.5-alpha.3] - 2024-02-11
+            ## [0.9.5-alpha.2] - 2024-02-10
+            ## [0.9.5-alpha.1] - 2024-02-06
+            ## [0.9.4] - 2024-02-06
+            ## [0.9.3] - 2024-01-16
+            
+            [Unreleased]: https://github.com/JetBrains/gradle-changelog-plugin/compare/v0.9.5-alpha.6...HEAD
+            [0.9.5-alpha.2]: https://github.com/JetBrains/gradle-changelog-plugin/compare/v0.9.5-alpha.1...v0.9.5-alpha.2
+            [0.9.5-alpha.1]: https://github.com/JetBrains/gradle-changelog-plugin/compare/v0.9.4...v0.9.5-alpha.1
+            [0.9.5-alpha.3]: https://github.com/JetBrains/gradle-changelog-plugin/compare/v0.9.5-alpha.2...v0.9.5-alpha.3
+            [0.9.4]: https://github.com/JetBrains/gradle-changelog-plugin/compare/v0.9.3...v0.9.4
+            [0.9.3]: https://github.com/JetBrains/gradle-changelog-plugin/compare/v0.9.3...v0.9.2
+            """.trimIndent()
+
+        project.evaluate()
+
+        runTask(PATCH_CHANGELOG_TASK_NAME)
+
+        assertMarkdown(
+            """
+            # Changelog
+
+            ## [Unreleased]
+
+            ### Added
+
+            ### Fixed
+
+            ## [0.9.5-alpha.3] - 2024-02-11
+
+            ## [0.9.5-alpha.2] - 2024-02-10
+
+            ## [0.9.5-alpha.1] - 2024-02-06
+
+            ## [0.9.4] - 2024-02-06
+
+            ## [0.9.3] - 2024-01-16
+
+            [Unreleased]: https://github.com/JetBrains/gradle-changelog-plugin/compare/v0.9.5-alpha.6...HEAD
+            [0.9.5-alpha.3]: https://github.com/JetBrains/gradle-changelog-plugin/compare/v0.9.5-alpha.2...v0.9.5-alpha.3
+            [0.9.5-alpha.2]: https://github.com/JetBrains/gradle-changelog-plugin/compare/v0.9.5-alpha.1...v0.9.5-alpha.2
+            [0.9.5-alpha.1]: https://github.com/JetBrains/gradle-changelog-plugin/compare/v0.9.4...v0.9.5-alpha.1
+            [0.9.4]: https://github.com/JetBrains/gradle-changelog-plugin/compare/v0.9.3...v0.9.4
+            [0.9.3]: https://github.com/JetBrains/gradle-changelog-plugin/compare/v0.9.3...v0.9.2
+            """.trimIndent(),
+            extension.render()
+        )
+    }
+
+    @Test
     fun `patched changelog contains an empty line at the end`() {
         runTask(PATCH_CHANGELOG_TASK_NAME)
 


### PR DESCRIPTION
# Pull Request Details

* Fix `compareTo` for versions that have equal major, minor and patch versions and both contain a hyphen

## Description

Assume that if all major, minor and patch versions are the same, a version with a hyphen is older than a version without one.

## Related Issue

Fix #171

## Motivation and Context

When two versions e.g. `0.9.5-alpha.3` and `0.9.5-alpha.4` both contained a hyphen, the `compareTo` always returned `-1` no matter which was left or right.
This violates the `compareTo` contract, causing issues like #171. 

## How Has This Been Tested

If I put the full changelog from [here](https://github.com/Hannah-Sten/TeXiFy-IDEA/blob/ff086f2e05493232acdb1a17216a471de238d7dc/CHANGELOG.md?plain=1#L1) in the test then I reproduce #171. Unfortunately I did not manage to create a minimal test for this, but with this change for me the issue is fixed.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the [**README**](README.md).
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
